### PR TITLE
Add unit tests for fasting logic and persistence

### DIFF
--- a/FastingAppTests/FastingAppTests.swift
+++ b/FastingAppTests/FastingAppTests.swift
@@ -1,35 +1,63 @@
-//
-//  FastingAppTests.swift
-//  FastingAppTests
-//
-//  Created by Dmytro Golub on 10/08/2025.
-//
-
 import XCTest
+@testable import FastingApp
 
 final class FastingAppTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults.standard
+        for key in defaults.dictionaryRepresentation().keys {
+            defaults.removeObject(forKey: key)
         }
     }
 
+    @MainActor
+    func testStartAndEndFast() async {
+        let vm = FastingViewModel()
+        vm.reminders.enabled = false
+        vm.plan = .custom(hours: 8)
+        let start = Date()
+        XCTAssertNil(vm.active)
+        await vm.startFast(now: start)
+        XCTAssertNotNil(vm.active)
+        XCTAssertEqual(vm.sessions.count, 1)
+        XCTAssertEqual(vm.active?.start, start)
+        XCTAssertEqual(vm.sessions.first?.planHours, vm.plan.fastingHours)
+        let end = start.addingTimeInterval(3600)
+        vm.endFast(at: end)
+        XCTAssertNil(vm.active)
+        XCTAssertEqual(vm.sessions.first?.completedAt, end)
+    }
+
+    func testPersistenceEncodingDecoding() {
+        let p = Persistence.shared
+        let start = Date()
+        let sessions = [
+            FastSession(id: UUID(), planHours: 16, start: start, end: nil, completedAt: nil),
+            FastSession(id: UUID(), planHours: 18, start: start.addingTimeInterval(-3600), end: nil, completedAt: start.addingTimeInterval(-1800))
+        ]
+        p.saveSessions(sessions)
+        let loadedSessions = p.loadSessions()
+        XCTAssertEqual(loadedSessions, sessions.sorted { $0.start > $1.start })
+        p.savePlan(.custom(hours: 10))
+        XCTAssertEqual(p.loadPlan(), .custom(hours: 10))
+        let reminders = ReminderSettings(enabled: true, startAlert: false, endAlert: false, preEndMinutes: nil, snoozeMinutes: 5)
+        p.saveReminders(reminders)
+        XCTAssertEqual(p.loadReminders(), reminders)
+    }
+
+    @MainActor
+    func testProgressAndHmsString() async {
+        let vm = FastingViewModel()
+        vm.reminders.enabled = false
+        vm.plan = .custom(hours: 10)
+        let start = Date()
+        await vm.startFast(now: start)
+        XCTAssertEqual(vm.progress(now: start), 0, accuracy: 0.001)
+        let mid = start.addingTimeInterval(5 * 3600)
+        XCTAssertEqual(vm.progress(now: mid), 0.5, accuracy: 0.001)
+        let after = start.addingTimeInterval(15 * 3600)
+        XCTAssertEqual(vm.progress(now: after), 1, accuracy: 0.001)
+        XCTAssertEqual(FastingViewModel.hmsString(from: 3661), "1h 01m")
+        XCTAssertEqual(FastingViewModel.hmsString(from: -10), "0h 00m")
+    }
 }


### PR DESCRIPTION
## Summary
- test start and end fast lifecycle in `FastingViewModel`
- verify JSON persistence of sessions, plan, and reminder settings
- check `progress` calculation and `hmsString` formatting

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898f21fdd2883318eea73cdb3c2beac