### PR TITLE
Centralize short time formatting and 24-hour option

### DIFF
--- a/FastingApp/Utilities/Date+Formatting.swift
+++ b/FastingApp/Utilities/Date+Formatting.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Date {
+    static func shortTimeString(_ date: Date, is24h: Bool) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        if is24h {
+            formatter.dateFormat = "HH:mm"
+        } else {
+            formatter.timeStyle = .short
+        }
+        return formatter.string(from: date)
+    }
+}

--- a/FastingApp/Utilities/LocalNotify.swift
+++ b/FastingApp/Utilities/LocalNotify.swift
@@ -13,7 +13,7 @@ enum LocalNotify {
         }
     }
 
-    static func scheduleEndNotification(for session: FastSession, preEndMinutes: Int?, snoozeMinutes: Int?) async {
+    static func scheduleEndNotification(for session: FastSession, preEndMinutes: Int?, snoozeMinutes: Int?, is24h: Bool) async {
         let center = UNUserNotificationCenter.current()
         center.removeAllPendingNotificationRequests()
         let now = Date()
@@ -22,7 +22,7 @@ enum LocalNotify {
             guard fire > now else { return }
             let content = UNMutableNotificationContent()
             content.title = title
-            content.body = "Your \(session.planHours):\(24 - session.planHours) fast finishes at \(timeString(fire))."
+            content.body = "Your \(session.planHours):\(24 - session.planHours) fast finishes at \(Date.shortTimeString(fire, is24h: is24h))."
             content.sound = .default
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: fire.timeIntervalSinceNow, repeats: false)
             center.add(UNNotificationRequest(identifier: id, content: content, trigger: trigger))
@@ -50,10 +50,4 @@ enum LocalNotify {
         try await center.add(UNNotificationRequest(identifier: UUID().uuidString + ".snooze", content: content, trigger: trigger))
     }
 
-    static func timeString(_ date: Date) -> String {
-        let fmt = DateFormatter()
-        fmt.timeStyle = .short
-        fmt.dateStyle = .none
-        return fmt.string(from: date)
-    }
 }

--- a/FastingApp/ViewModels/FastingViewModel.swift
+++ b/FastingApp/ViewModels/FastingViewModel.swift
@@ -38,7 +38,7 @@ final class FastingViewModel: ObservableObject {
         Persistence.shared.saveSessions(sessions)
         if reminders.enabled && reminders.endAlert {
             _ = await LocalNotify.requestAuth()
-            await LocalNotify.scheduleEndNotification(for: s, preEndMinutes: reminders.preEndMinutes, snoozeMinutes: reminders.snoozeMinutes)
+            await LocalNotify.scheduleEndNotification(for: s, preEndMinutes: reminders.preEndMinutes, snoozeMinutes: reminders.snoozeMinutes, is24h: timeFormat24h)
         }
     }
 

--- a/FastingApp/Views/Home/HomeView.swift
+++ b/FastingApp/Views/Home/HomeView.swift
@@ -17,7 +17,7 @@ struct HomeView: View {
             Group {
                 if vm.status == .fasting, let s = vm.active {
                     Text("Remaining: \(FastingViewModel.hmsString(from: s.scheduledEnd.timeIntervalSince(now)))")
-                    Text("Start: \(timeString(s.start))  |  End: \(timeString(s.scheduledEnd))")
+                    Text("Start: \(Date.shortTimeString(s.start, is24h: vm.timeFormat24h))  |  End: \(Date.shortTimeString(s.scheduledEnd, is24h: vm.timeFormat24h))")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                     Button(role: .destructive) { vm.endFast() } label: { Text("Stop Fast") }
@@ -39,12 +39,6 @@ struct HomeView: View {
         .navigationTitle("Fasting")
     }
 
-    func timeString(_ d: Date) -> String {
-        let f = DateFormatter()
-        f.timeStyle = .short
-        f.dateStyle = .none
-        return f.string(from: d)
-    }
 }
 
 #Preview("Home (Fasting)") {


### PR DESCRIPTION
## Summary
- add `Date.shortTimeString` helper for 24h or locale formats
- use shared formatter in `LocalNotify` and `HomeView`
- pass `timeFormat24h` to notification scheduling

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898f4bc07b08331b13d1383d35ea6aa